### PR TITLE
fix signed integer oveflow which is UB and silencing other warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 test
 *.d
 base45
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ INC_FLAGS :=
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP
 
+
 tests: all $(TARGET_TEST)
 	./test
 	for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 17 19 41 42 43 103 1002 10009 100007 1000001 0; do \

--- a/base45.c
+++ b/base45.c
@@ -21,7 +21,7 @@
 
 static const char BASE45_CHARSET[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
 
-static char _C2I[256] = {
+static unsigned char _C2I[256] = {
 	255,255,255,255, 255,255,255,255, 255,255,255,255, 255,255,255,255,
 	255,255,255,255, 255,255,255,255, 255,255,255,255, 255,255,255,255,
 	36, 255,255,255,  37, 38,255,255, 255,255, 39, 40, 255, 41, 42, 43,
@@ -47,7 +47,7 @@ int base45_encode(char * dst, size_t *_max_dst_len, const unsigned char * src, s
   size_t out_len = 0, max_dst_len;
   max_dst_len = _max_dst_len ? *_max_dst_len : src_len * 4;
 
-  for(int i = 0; i < src_len; i+=2) {
+  for(unsigned i = 0; i < src_len; i+=2) {
      if (src_len - i > 1) {
         int x = ((src[i])<<8) + src[i+1];
 
@@ -88,7 +88,7 @@ int base45_encode(char * dst, size_t *_max_dst_len, const unsigned char * src, s
   return 0;
 }
 
-int base45_decode(unsigned char * dst, size_t * _max_dst_len, const char * src, size_t src_len) {
+int base45_decode(unsigned char * dst, size_t * _max_dst_len, const char *src, size_t src_len) {
   size_t out_len = 0, max_dst_len;
   max_dst_len = _max_dst_len  ? *_max_dst_len : src_len;
 
@@ -101,19 +101,19 @@ int base45_decode(unsigned char * dst, size_t * _max_dst_len, const char * src, 
   if (src_len == 0)
 	src_len = strlen(src);
 
-  for(int i = 0; i < src_len; i+=3) {
+  for(unsigned i = 0; i < src_len; i+=3) {
      int x,a,b;
 
      if (src_len - i < 2) 
-	return -1;
+	    return -1;
 
-     if ((255 == (a = _C2I[src[i]])) || (255 == (b = _C2I[src[i+1]]))) 
+     if ((255 == (a = _C2I[(unsigned char)src[i]])) || (255 == (b = _C2I[(unsigned char)src[i+1]])))
 	return -1;
 
      x = a + 45 * b;
 
      if (src_len - i >= 3) {
-        if (255 == (a = _C2I[src[i+2]])) 
+        if (255 == (a = _C2I[(unsigned char)src[i+2]]))
 	    return -1;
 
         x += a * 45 * 45;

--- a/test.c
+++ b/test.c
@@ -21,7 +21,7 @@ void check(char * in, char * out) {
 	assert(0 == bcmp(dec,in,dlen));
 
 	printf("base64(\"%s\") -> \"%s\"\n", (char*)dec, enc);
-};
+}
 
 int main(int argc, char **argv) {
  check("Hello!!","%69 VD92EX0");
@@ -30,4 +30,4 @@ int main(int argc, char **argv) {
  check("COVID-19","-M8*+A%R81A6");
  check("2021 Digital Green Certificates for travel",
 	"NF6OF6P34SED-EDAECS34ZKE1$CO345$CBWER.CGPC7WE.OEX.CBJEKWEKEC: C");
-};
+}

--- a/test.d
+++ b/test.d
@@ -1,3 +1,2 @@
 test.o: test.c base45.h
-
 base45.h:


### PR DESCRIPTION
As you should know [signed integer overflow is **UB**](https://stackoverflow.com/questions/54556973/signed-integer-and-unsigned-integer), apart from that I strongly suggest you enable at least the compiler warnings (`-Wall` and `-Wextra` flags), i haven't looked for any other bugs.